### PR TITLE
Upgrade local to Python 3.11, add 3.12 to CI matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,9 +22,10 @@ jobs:
 
     strategy:
       matrix:
-        # 3.12 excluded: tropycal>=1.4 _version.py uses pkg_resources which
-        # is not bundled in 3.12+. Re-add when tropycal ships a fix.
-        python-version: ['3.10', '3.11']
+        # 3.13+ excluded: tropycal>=1.4 _version.py uses pkg_resources, which
+        # was removed from setuptools 81+. We pin setuptools<81 in
+        # requirements.txt as a workaround. Re-evaluate when tropycal ships a fix.
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v6

--- a/.gitignore
+++ b/.gitignore
@@ -238,3 +238,4 @@ config.ini
 *.bak
 *.backup
 *~
+.venv*

--- a/docs/PROJECT_CONTEXT.md
+++ b/docs/PROJECT_CONTEXT.md
@@ -119,10 +119,9 @@ ace-tracker/
 - No Jinja2 templates yet (Session 3)
 - No realtime data failover chain yet (Session 2)
 - Branch protection rules not enabled in GitHub Settings (CODEOWNERS exists but not enforced — Jeremy must enable in UI)
-- Local Python is 3.9 (EOL) — upgrade to 3.11 before Session 2
 
 ### Known Issues / Risks
-- Tropycal `pkg_resources` bug on Python 3.12 — unpatched 18+ months. Python 3.12 excluded from CI with inline comment explaining why.
+- Tropycal `_version.py` uses `pkg_resources`, which was removed from setuptools 81+. Worked around by pinning `setuptools<81` in `requirements.txt`. CI tests 3.10/3.11/3.12. Revisit when tropycal ships a fix or replaces setuptools_scm version detection.
 - HURDAT2 lag: 2025 season data won't be in HURDAT2 until spring 2026. Historical comparison will show 2025 as incomplete until then — needs disclosure on site.
 - No rollback plan for gh-pages yet — a bad cron run could push broken HTML. Add validation step before deploy (check HTML file exists and is >1kb) when activating publish.yml.
 
@@ -172,8 +171,7 @@ ace-tracker/
 2. **Activate publish.yml** — uncomment deploy steps, enable GitHub Pages in repo Settings
 3. **Register `aceofcanes.com`** on Namecheap (~$12/yr, free WHOIS privacy)
 4. **Add Cloudflare proxy** in front of GitHub Pages after domain is live
-5. **Upgrade local Python 3.9 → 3.11** before Session 2 (`brew install python@3.11`)
-6. **Session 2:** Build realtime data failover chain
+5. **Session 2:** Build realtime data failover chain
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ openpyxl>=3.1.5
 tropycal>=1.4
 shapely>=2.1.2
 cartopy>=0.25.0
+setuptools<81


### PR DESCRIPTION
- Pin setuptools<81 to work around tropycal pkg_resources usage
- Add 3.12 to CI matrix (verified locally)
- Update tests.yml comment to reflect actual root cause
- Update PROJECT_CONTEXT.md: remove stale 3.9 line, fix tropycal note
- Add .venv* to .gitignore