### PR TITLE
Add pre-PR branch sync rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,12 @@ pip3 install -r requirements.txt
 - **Only @jeremypfi can approve and merge PRs** (CODEOWNERS + branch protection)
 - All 25 tests must pass before committing — run `/pre-commit` skill
 - Never commit `data/*.xlsx` or `data/*.html` — gitignored
+- **Before opening any PR:** fetch origin and merge main into the branch first:
+  ```bash
+  git fetch origin
+  git merge origin/main --no-edit
+  git push
+  ```
 
 ## Known Issue
 


### PR DESCRIPTION
## Summary
Adds a rule to CLAUDE.md requiring a `git fetch origin && git merge origin/main` before opening any PR, to avoid the "branch out of date" warning that blocks merging.

Also saved to Claude's persistent memory so it applies in future sessions automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)