### PR TITLE
Add custom domain aceofcanes.com

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,9 @@ jobs:
         python ace_tracker.py
 
     - name: Prepare for deployment
-      run: cp data/ACE_Dashboard.html data/index.html
+      run: |
+        cp data/ACE_Dashboard.html data/index.html
+        cp CNAME data/CNAME
 
     - name: Upload Pages artifact
       uses: actions/upload-pages-artifact@v5

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+aceofcanes.com


### PR DESCRIPTION
## Summary
- Adds `CNAME` file pointing to `aceofcanes.com`
- Updates `publish.yml` to copy `CNAME` into the `data/` artifact before deploy so GitHub Pages respects the custom domain on every run

## Test plan
- [ ] Merge and trigger manual workflow run (Actions → Publish Dashboard → Run workflow)
- [ ] Verify site loads at aceofcanes.com after DNS propagates
- [ ] Confirm HTTPS padlock appears (may take up to 24h for cert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)