### PR TITLE
Improve storm track map: bigger with land context

### DIFF
--- a/ace_tracker.py
+++ b/ace_tracker.py
@@ -1232,9 +1232,9 @@ def generate_dashboard_html(basin_data):
   tr.active-storm-row {{ border-left:3px solid #4caf50; }}
   .track-row td {{ padding:0; border-bottom:2px solid var(--border); }}
   .track-panel {{ overflow:hidden; max-height:0; transition:max-height 0.35s ease; background:var(--card); }}
-  .track-panel.open {{ max-height:620px; }}
+  .track-panel.open {{ max-height:720px; }}
   .track-inner {{ padding:12px 14px 14px; }}
-  .track-map {{ height:255px; border-radius:8px; border:1px solid var(--border); margin-bottom:10px; }}
+  .track-map {{ height:320px; border-radius:8px; border:1px solid var(--border); margin-bottom:10px; }}
   .storm-meta {{ display:grid; grid-template-columns:repeat(3,1fr); gap:8px; margin-bottom:10px; }}
   .meta-box {{ background:var(--box); border-radius:6px; padding:8px 10px; }}
   .meta-label {{ color:var(--muted); font-size:0.72em; text-transform:uppercase; }}
@@ -1361,7 +1361,7 @@ function _buildMap(slug){{
     mk.bindTooltip('<b>'+d.name+'</b><br>'+p.time+'<br>'+p.status+' \xb7 '+p.wind+'kt',{{direction:'top',offset:[0,-6]}});
     if(last&&d.active)mk.bindPopup('<b>Current Position</b><br>'+p.time+'<br>'+p.status+' \xb7 '+p.wind+'kt',{{maxWidth:160}}).openPopup();
   }});
-  if(lls.length)map.fitBounds(L.latLngBounds(lls),{{padding:[25,25]}});
+  if(lls.length)map.fitBounds(L.latLngBounds(lls),{{padding:[50,50],maxZoom:6}});
 }}
 </script>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>


### PR DESCRIPTION
## Summary

Track map was a zoomed-in gray squiggle in a black ocean with no geographic context.

- **Map height** 255px → 320px — more room to read the track
- **`fitBounds` maxZoom capped at 6** — forces the map to pull back far enough that coastlines are always visible in frame; Amanda's track now shows the Mexican/Central American coast for reference
- **`fitBounds` padding** 25px → 50px — track no longer fills edge-to-edge
- **`track-panel` max-height** bumped 620px → 720px to accommodate the taller map

## Test plan
- [x] Expand Amanda (or any Pacific storm) — coastline should be visible
- [x] Expand an Atlantic storm — should show Caribbean/US East Coast for context
- [x] Map still fits cleanly inside the accordion without overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)