### PR TITLE
Fix truncated Leaflet SRI hash — maps were blocked

### DIFF
--- a/ace_tracker.py
+++ b/ace_tracker.py
@@ -1834,7 +1834,7 @@ function _buildMap(slug){{
   if(lls.length)map.fitBounds(L.latLngBounds(lls),{{padding:[50,50],maxZoom:6}});
 }}
 </script>
-<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha384-cxOPjt7s7Iz04uaHJceBmS+qpjv2JkIHNVcuOrM+YHwZOmJGBXI00mdUXEq65HT" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha384-cxOPjt7s7Iz04uaHJceBmS+qpjv2JkIHNVcuOrM+YHwZOmJGBXI00mdUXEq65HTH" crossorigin="anonymous"></script>
 <div id="global-tip" class="global-tip"></div>
 <script>
 (function(){{

--- a/test_ace_tracker.py
+++ b/test_ace_tracker.py
@@ -371,6 +371,25 @@ class TestHTMLGeneration(unittest.TestCase):
         self.assertIn('All Seasons', result)
         self.assertIn('2005', result)
 
+    def test_leaflet_sri_hashes_present(self):
+        """Dashboard HTML contains the correct full SRI hashes for Leaflet.
+
+        Guards against truncated or missing integrity attributes that would
+        cause the browser to silently block the map library.
+        """
+        basin_data = self._make_basin_data()
+        result = generate_dashboard_html(basin_data)
+        # Both the full hash value AND crossorigin must be present
+        self.assertIn(
+            'sha384-cxOPjt7s7Iz04uaHJceBmS+qpjv2JkIHNVcuOrM+YHwZOmJGBXI00mdUXEq65HTH',
+            result, "Leaflet JS SRI hash missing or truncated"
+        )
+        self.assertIn(
+            'sha384-sHL9NAb7lN7rfvG5lfHpm643Xkcjzp4jFvuavGOndn6pjVqS6ny56CAt3nsEVT4H',
+            result, "Leaflet CSS SRI hash missing or truncated"
+        )
+        self.assertIn('crossorigin="anonymous"', result)
+
     def test_html_escape_applied(self):
         """html_escape() is reachable from inside the generator functions
         (guards against the 'html' local-variable shadowing bug)."""


### PR DESCRIPTION
## Summary

The two SRI hashes were computed with a single `curl | openssl` pipeline per line but the output ran together with no newline separator. The JS hash was missing its trailing `H`, causing the browser to block the Leaflet script and break all track maps.

**Browser error:** `Failed to find a valid digest in the 'integrity' attribute for resource leaflet.js with computed SHA-384 integrity 'cxOPjt7s7Iz04uaHJceBmS+qpjv2JkIHNVcuOrM+YHwZOmJGBXI00mdUXEq65HTH'`

**Fix:** Added the missing `H` to match what the browser actually computes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)