### PR TITLE
Retry GitHub Pages deploy on transient failures

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,5 +87,28 @@ jobs:
       with:
         path: ./data
 
+    # actions/deploy-pages occasionally hits transient 5xx errors from the
+    # Pages backend (e.g. "503 ... is githubstatus.com reporting a Pages
+    # outage?"). Retry a couple of times with a short backoff before giving up.
     - name: Deploy to GitHub Pages
+      id: deploy_attempt_1
+      uses: actions/deploy-pages@v5
+      continue-on-error: true
+
+    - name: Wait before retry
+      if: steps.deploy_attempt_1.outcome == 'failure'
+      run: sleep 30
+
+    - name: Deploy to GitHub Pages (retry 1)
+      id: deploy_attempt_2
+      if: steps.deploy_attempt_1.outcome == 'failure'
+      uses: actions/deploy-pages@v5
+      continue-on-error: true
+
+    - name: Wait before final retry
+      if: steps.deploy_attempt_2.outcome == 'failure'
+      run: sleep 60
+
+    - name: Deploy to GitHub Pages (retry 2)
+      if: steps.deploy_attempt_2.outcome == 'failure'
       uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- The 19:10 UTC publish run failed with a 503 from `actions/deploy-pages` ("is githubstatus.com reporting a Pages outage? Please re-run the deployment at a later time.") — a transient backend issue, not a bug in `ace_tracker.py` or the generated data (all prior steps succeeded).
- Adds up to two retries (30s then 60s backoff) around the deploy step before letting the job actually fail, so a one-off Pages hiccup doesn't block a publish cycle.

## Test plan
- [x] `python3 test_ace_tracker.py` — all 34 tests pass (unaffected, workflow-only change)
- [x] Validated `publish.yml` YAML syntax
- [ ] Confirm next scheduled/manual run deploys successfully (with or without needing a retry)