### PR TITLE
Add cumulative ACE pace chart to the dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Same thresholds for both Atlantic and Eastern Pacific:
 
 ```bash
 python3 ace_tracker.py        # generates HTML files in data/
-python3 test_ace_tracker.py   # 34 tests — ALL must pass before committing
+python3 test_ace_tracker.py   # 48 tests — ALL must pass before committing
 pip3 install -r requirements.txt
 ```
 
@@ -47,12 +47,12 @@ pip3 install -r requirements.txt
 
 `ace_tracker.py`: CLI entrypoint — `process_basin()` and `main()`, wiring `ace_data.py` and `ace_html.py` together. Run via `python3 ace_tracker.py`.
 
-`test_ace_tracker.py`: 34 tests across 10 classes — categorization, ACE formula, NOAA classification, storm finalization, yearly totals, similar-season matching. Imports directly from `ace_data.py`/`ace_html.py`.
+`test_ace_tracker.py`: 48 tests across 11 classes — categorization, ACE formula, NOAA classification, storm finalization, yearly totals, similar-season matching, ACE pace chart data. Imports directly from `ace_data.py`/`ace_html.py`.
 
 ## Repository Rules
 
 - **Only @jeremypfi can approve and merge PRs** (CODEOWNERS + branch protection)
-- All 34 tests must pass before committing — run `/pre-commit` skill
+- All 48 tests must pass before committing — run `/pre-commit` skill
 - Never commit `data/*.html` — gitignored
 - **Before opening any PR:** fetch origin and merge main into the branch first:
   ```bash

--- a/ace_data.py
+++ b/ace_data.py
@@ -919,14 +919,11 @@ def calculate_same_date_stats(historical_storms, basin_key, target_date=None):
 
         for s in yr_storms:
             start = s.get('start_date')
-            end   = s.get('end_date')
             if start is None:
                 continue
             # Strip timezone so comparisons work
             if getattr(start, 'tzinfo', None):
                 start = start.replace(tzinfo=None)
-            if end and getattr(end, 'tzinfo', None):
-                end = end.replace(tzinfo=None)
 
             if start > hist_cutoff:
                 continue  # Storm hadn't formed yet

--- a/ace_data.py
+++ b/ace_data.py
@@ -844,6 +844,33 @@ def find_similar_seasons(target_ace, yearly_totals, exclude_year=None):
 
 
 
+def _storm_ace_at_cutoff(storm, cutoff):
+    """ACE a storm had contributed as of `cutoff` (a naive datetime).
+
+    0.0 if the storm hadn't formed yet by `cutoff`; the storm's full ACE if
+    it had already ended by `cutoff`; otherwise a linear proration by
+    elapsed/total days. Shared by calculate_same_date_stats (one date, many
+    years) and calculate_ace_pace (many dates, few years) so both features
+    can never independently drift on the same number.
+    """
+    start = storm.get('start_date')
+    end = storm.get('end_date')
+    if start is None:
+        return 0.0
+    if getattr(start, 'tzinfo', None):
+        start = start.replace(tzinfo=None)
+    if end and getattr(end, 'tzinfo', None):
+        end = end.replace(tzinfo=None)
+    if start > cutoff:
+        return 0.0
+    storm_ace = storm.get('ace', 0.0)
+    if end is None or end <= cutoff:
+        return storm_ace
+    total_days = max(1, (end - start).days)
+    elapsed = max(0, (cutoff - start).days)
+    return storm_ace * min(1.0, elapsed / total_days)
+
+
 def calculate_same_date_stats(historical_storms, basin_key, target_date=None):
     """Compute historical averages for counts and ACE as of the same calendar
     date across all completed seasons since START_YEAR.
@@ -910,14 +937,7 @@ def calculate_same_date_stats(historical_storms, basin_key, target_date=None):
             if s['max_wind'] >= 96:
                 majors += 1
 
-            # Prorate ACE for storms still active at the cutoff
-            storm_ace = s.get('ace', 0.0)
-            if end is None or end <= hist_cutoff:
-                ace += storm_ace
-            else:
-                total_days = max(1, (end - start).days)
-                elapsed    = max(0, (hist_cutoff - start).days)
-                ace += storm_ace * min(1.0, elapsed / total_days)
+            ace += _storm_ace_at_cutoff(s, hist_cutoff)
 
         sd_named[year]     = named
         sd_hurricanes[year] = hurricanes
@@ -935,6 +955,91 @@ def calculate_same_date_stats(historical_storms, basin_key, target_date=None):
         'date_label':    date_label,
     }
 
+
+def _percentile(sorted_values, pct):
+    """Linear-interpolation percentile over an already-sorted list."""
+    n = len(sorted_values)
+    if n == 0:
+        return 0.0
+    if n == 1:
+        return sorted_values[0]
+    k = (n - 1) * (pct / 100)
+    f, c = int(k), min(int(k) + 1, n - 1)
+    if f == c:
+        return sorted_values[f]
+    return sorted_values[f] * (c - k) + sorted_values[c] * (k - f)
+
+
+def calculate_ace_pace(historical_storms, basin_key, as_of_date=None):
+    """Build day-by-day cumulative ACE curves for the dashboard pace chart:
+    historical climatology (mean/p25/p75, excluding the current season),
+    this season's own cumulative curve (prorated up to `as_of_date`, using
+    the same proration logic as calculate_same_date_stats), and last
+    season's complete curve.
+
+    Returns None if there is no historical data to build a climatology from.
+    """
+    if as_of_date is None:
+        as_of_date = datetime.now()
+
+    if basin_key == 'atlantic':
+        ssm, ssd = 6, 1   # June 1
+    else:
+        ssm, ssd = 5, 15  # May 15
+
+    season_start = datetime(as_of_date.year, ssm, ssd)
+    season_end = datetime(as_of_date.year, 11, 30)
+    total_days = (season_end - season_start).days
+    today_index = min(total_days, max(0, (as_of_date - season_start).days))
+
+    storms_by_year = {}
+    for s in historical_storms:
+        storms_by_year.setdefault(s['year'], []).append(s)
+
+    climatology_years = [y for y in storms_by_year if y < as_of_date.year]
+    if not climatology_years:
+        return None
+
+    def cumulative_curve(year, storms):
+        curve = []
+        for d in range(total_days + 1):
+            cutoff = datetime(year, ssm, ssd) + timedelta(days=d)
+            curve.append(round(sum(_storm_ace_at_cutoff(s, cutoff) for s in storms), 2))
+        return curve
+
+    climatology_curves = [cumulative_curve(y, storms_by_year[y]) for y in climatology_years]
+
+    climatology_mean = []
+    climatology_p25 = []
+    climatology_p75 = []
+    for d in range(total_days + 1):
+        day_values = sorted(curve[d] for curve in climatology_curves)
+        climatology_mean.append(round(sum(day_values) / len(day_values), 2))
+        climatology_p25.append(round(_percentile(day_values, 25), 2))
+        climatology_p75.append(round(_percentile(day_values, 75), 2))
+
+    current_year = as_of_date.year
+    current_full = cumulative_curve(current_year, storms_by_year.get(current_year, []))
+    current_season = [v if d <= today_index else None for d, v in enumerate(current_full)]
+
+    last_year = current_year - 1
+    last_season = cumulative_curve(last_year, storms_by_year[last_year]) if last_year in storms_by_year else None
+
+    day_labels = [(season_start + timedelta(days=d)).strftime('%b %-d') for d in range(total_days + 1)]
+
+    return {
+        'day_labels': day_labels,
+        'climatology_mean': climatology_mean,
+        'climatology_p25': climatology_p25,
+        'climatology_p75': climatology_p75,
+        'current_season': current_season,
+        'last_season': last_season,
+        'today_index': today_index,
+        'current_year': current_year,
+        'last_year': last_year,
+        'years_used': len(climatology_years),
+        'basin_key': basin_key,
+    }
 
 
 # ===============================================================================

--- a/ace_html.py
+++ b/ace_html.py
@@ -479,12 +479,14 @@ def generate_dashboard_html(basin_data):
     --accent-h3:#81d4fa; --text:#e0e6ed; --text-strong:#ffffff; --muted:#78909c;
     --muted-dark:#546e7a; --border:#1e3a5f; --danger:#ef5350; --danger-bg:#2a1a1a;
     --danger-text:#ef8a80; --total-row:#1a2d4a; --sources-bg:#0d1b2a; --gauge-bg:#1e3a5f;
+    --pace-last:#ffb74d;
   }}
   [data-theme="light"] {{
     --bg:#f0f4f8; --card:#ffffff; --box:#e8f0fe; --accent:#0277bd; --accent2:#0288d1;
     --accent-h3:#01579b; --text:#1a2d4a; --text-strong:#0a1628; --muted:#607d8b;
     --muted-dark:#455a64; --border:#b0bec5; --danger:#d32f2f; --danger-bg:#ffeaea;
     --danger-text:#c62828; --total-row:#e8f0fe; --sources-bg:#e2ecf7; --gauge-bg:#c9daf8;
+    --pace-last:#e65100;
   }}
   * {{ margin:0; padding:0; box-sizing:border-box; }}
   body {{ font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--bg); color:var(--text); padding:12px; transition:background 0.2s,color 0.2s; }}
@@ -690,7 +692,7 @@ var _paceCharts={{}};
 function _paceColors(){{
   var s=getComputedStyle(document.documentElement);
   var g=function(v){{return s.getPropertyValue(v).trim();}};
-  return {{accent:g('--accent'),accent2:g('--accent2'),muted:g('--muted'),mutedDark:g('--muted-dark'),border:g('--border')}};
+  return {{accent:g('--accent'),accent2:g('--accent2'),muted:g('--muted'),mutedDark:g('--muted-dark'),border:g('--border'),last:g('--pace-last')}};
 }}
 function _hexToRgba(hex,a){{
   var h=hex.replace('#','');
@@ -710,7 +712,7 @@ function _renderPaceChart(basinKey){{
     {{label:'Historical average',data:d.climatology_mean,borderColor:colors.muted,borderWidth:2,borderDash:[5,5],pointRadius:0}}
   ];
   if(d.last_season){{
-    datasets.push({{label:'Last season',data:d.last_season,borderColor:colors.mutedDark,borderWidth:1.5,pointRadius:0}});
+    datasets.push({{label:'Last season',data:d.last_season,borderColor:colors.last,borderWidth:2.5,pointRadius:0}});
   }}
   datasets.push({{label:'This season',data:d.current_season,borderColor:colors.accent,borderWidth:3,pointRadius:0,spanGaps:false}});
   _paceCharts[basinKey]=new Chart(el,{{
@@ -720,7 +722,7 @@ function _renderPaceChart(basinKey){{
       responsive:true,maintainAspectRatio:false,
       interaction:{{mode:'index',intersect:false}},
       plugins:{{
-        legend:{{display:false}},
+        legend:{{display:true,position:'top',labels:{{color:colors.muted,boxWidth:14,boxHeight:2,font:{{size:11}},filter:function(item){{return item.text!=='p75'&&item.text!=='p25';}}}}}},
         tooltip:{{filter:function(item){{return item.dataset.label!=='p75'&&item.dataset.label!=='p25';}}}}
       }},
       scales:{{
@@ -749,9 +751,10 @@ function _restylePaceCharts(){{
     chart.data.datasets.forEach(function(ds){{
       if(ds.label==='p25')ds.backgroundColor=_hexToRgba(colors.accent2,0.15);
       else if(ds.label==='Historical average')ds.borderColor=colors.muted;
-      else if(ds.label==='Last season')ds.borderColor=colors.mutedDark;
+      else if(ds.label==='Last season')ds.borderColor=colors.last;
       else if(ds.label==='This season')ds.borderColor=colors.accent;
     }});
+    chart.options.plugins.legend.labels.color=colors.muted;
     chart.options.scales.x.ticks.color=colors.muted;
     chart.options.scales.y.ticks.color=colors.muted;
     chart.options.scales.y.grid.color=colors.border;

--- a/ace_html.py
+++ b/ace_html.py
@@ -736,13 +736,18 @@ function _renderPaceChart(basinKey){{
 function _updatePaceStats(basinKey,d){{
   var todate=d.current_season[d.today_index]||0;
   var normal=d.climatology_mean[d.today_index]||0;
-  var pct=normal>0?(todate/normal*100):0;
+  // normal===0 this early in the season doesn't mean "on pace" if there's
+  // already ACE this season — it means the ratio isn't meaningful yet.
+  var pctText;
+  if(normal>0){{pctText=(todate/normal*100).toFixed(0)+'%';}}
+  else if(todate>0){{pctText='—';}}
+  else{{pctText='0%';}}
   var elT=document.getElementById('pace-todate-'+basinKey);
   var elN=document.getElementById('pace-normal-'+basinKey);
   var elP=document.getElementById('pace-pct-'+basinKey);
   if(elT)elT.textContent=todate.toFixed(1);
   if(elN)elN.textContent=normal.toFixed(1);
-  if(elP)elP.textContent=pct.toFixed(0)+'%';
+  if(elP)elP.textContent=pctText;
 }}
 function _restylePaceCharts(){{
   var colors=_paceColors();

--- a/ace_html.py
+++ b/ace_html.py
@@ -522,9 +522,9 @@ def generate_dashboard_html(basin_data):
   .nhc-issued {{ color:var(--muted); font-size:0.82em; }}
   .nhc-alert-link {{ color:var(--accent); text-decoration:none; font-size:0.88em; font-weight:500; }}
   .nhc-alert-link:hover {{ text-decoration:underline; }}
-  .stats-grid {{ display:grid; grid-template-columns:repeat(3,1fr); gap:8px; }}
-  .stat-box {{ background:var(--box); border-radius:8px; padding:10px; text-align:center; }}
-  .stat-box.ace-total {{ grid-column:span 3; }}
+  .stats-grid {{ display:flex; flex-wrap:wrap; gap:8px; }}
+  .stat-box {{ background:var(--box); border-radius:8px; padding:10px; text-align:center; flex:1 1 100px; }}
+  .stat-box.ace-total {{ flex:1 1 100%; }}
   .stat-label {{ color:var(--muted); font-size:0.75em; text-transform:uppercase; }}
   .stat-value {{ color:var(--text-strong); font-size:1.5em; font-weight:bold; }}
   .stat-value.small {{ font-size:1.1em; }}
@@ -566,7 +566,7 @@ def generate_dashboard_html(basin_data):
   .preseason-notice {{ background:var(--box); border-radius:8px; padding:14px 16px; margin:12px 0; border-left:4px solid var(--accent); font-size:0.9em; color:var(--text); text-align:center; line-height:1.5; }}
   .sim-link {{ color:var(--accent); text-decoration:none; }}
   .sim-link:hover {{ text-decoration:underline; }}
-  @media(min-width:768px) {{ body {{ max-width:900px; margin:0 auto; padding:24px; }} .stats-grid {{ grid-template-columns:repeat(6,1fr); }} .stat-box.ace-total {{ grid-column:span 6; }} }}
+  @media(min-width:768px) {{ body {{ max-width:900px; margin:0 auto; padding:24px; }} }}
   @media(min-width:1100px) {{ body {{ max-width:1100px; }} }}
   .storm-name-btn {{ background:none; border:none; color:var(--accent); cursor:pointer; font-size:inherit; padding:0; display:inline-flex; align-items:center; gap:4px; white-space:nowrap; text-decoration:underline dotted; }}
   .storm-name-btn:hover {{ color:var(--accent2); }}

--- a/ace_html.py
+++ b/ace_html.py
@@ -154,6 +154,25 @@ def _preseason_html(basin_key, yearly_totals, current_year):
 
 
 
+def _ace_pace_html(pace, basin_key):
+    """HTML chrome for the Season Pace chart. The chart itself and the
+    summary stat row are populated client-side from ACE_PACE — see
+    _renderPaceChart()/toggleTheme() JS below — so this only emits the
+    canvas and placeholder stat boxes."""
+    if not pace:
+        return ''
+    return f'''
+      <h3>Season Pace</h3>
+      <div class="pace-chart-wrap"><canvas id="pace-canvas-{basin_key}"></canvas></div>
+      <div class="pace-stats-mini">
+        <div class="meta-box"><div class="meta-label">ACE to Date</div><div class="meta-value" id="pace-todate-{basin_key}">—</div></div>
+        <div class="meta-box"><div class="meta-label">Normal for Today</div><div class="meta-value" id="pace-normal-{basin_key}">—</div></div>
+        <div class="meta-box"><div class="meta-label">vs. Normal</div><div class="meta-value" id="pace-pct-{basin_key}">—</div></div>
+      </div>
+      <p class="pace-caption">Historical range based on {pace['years_used']} seasons since {START_YEAR}.</p>'''
+
+
+
 # ===============================================================================
 # NHC ALERT BANNER
 # ===============================================================================
@@ -318,6 +337,7 @@ def generate_dashboard_html(basin_data):
 
     sections = []
     all_track_data = {}
+    all_pace_data = {}
     for bd in basin_data:
         if not bd:
             continue
@@ -410,17 +430,24 @@ def generate_dashboard_html(basin_data):
         disturbances   = fetch_nhc_disturbances(bd['basin_key'])
         nhc_alert      = _nhc_alert_html(disturbances)
 
+        ace_pace = bd.get('ace_pace')
+        pace_section = _ace_pace_html(ace_pace, bd['basin_key'])
+        if ace_pace:
+            all_pace_data[bd['basin_key']] = ace_pace
+
         sections.append(f'''
     <div class="basin-card" id="{bd['basin_key']}">
       <h2>{basin['name']} — {current_year} Season</h2>
       {_season_progress_html(bd['basin_key'], current_year)}
       {nhc_alert}
       {stats_grid}
+      {pace_section}
       {lower_section}
     </div>''')
 
-    # Escape </ sequences so the JSON blob can't break out of the <script> tag
+    # Escape </ sequences so the JSON blobs can't break out of the <script> tag
     _track_json = json.dumps(all_track_data).replace('</', '<\\/')
+    _pace_json = json.dumps(all_pace_data).replace('</', '<\\/')
 
     html = f'''<!DOCTYPE html>
 <html lang="en">
@@ -568,6 +595,10 @@ def generate_dashboard_html(basin_data):
   .nhc-link {{ font-size:0.78em; color:var(--muted); text-align:right; margin-top:6px; }}
   .nhc-link a {{ color:var(--accent); text-decoration:none; }}
   .nhc-link a:hover {{ text-decoration:underline; }}
+  .pace-chart-wrap {{ position:relative; height:240px; margin:12px 0 4px; }}
+  .pace-stats-mini {{ display:grid; grid-template-columns:repeat(3,1fr); gap:8px; margin:10px 0 4px; }}
+  .pace-caption {{ color:var(--muted); font-size:0.78em; text-align:center; margin-top:2px; }}
+  @media(min-width:768px) {{ .pace-chart-wrap {{ height:300px; }} }}
   .cone-graphic {{ margin-bottom:10px; }}
   .cone-graphic img {{ display:block; width:100%; height:auto; border-radius:8px; border:1px solid var(--border); }}
   .cone-credit {{ font-size:0.72em; color:var(--muted); text-align:center; margin-top:4px; }}
@@ -611,6 +642,7 @@ function show(id,btn) {{
   document.getElementById(id)?.classList.add('active');
   btn.classList.add('active');
   try{{history.replaceState(null,'','#'+id);}}catch(e){{}}
+  _renderPaceChart(id);
 }}
 function toggleTheme() {{
   var h=document.documentElement;
@@ -618,12 +650,15 @@ function toggleTheme() {{
   h.setAttribute('data-theme',light?'dark':'light');
   try{{localStorage.setItem('ace-theme',light?'dark':'light');}}catch(e){{}}
   document.getElementById('themeBtn').textContent=light?'☀':'☾';
+  _restylePaceCharts();
 }}
 document.addEventListener('DOMContentLoaded',function() {{
   document.getElementById('themeBtn').textContent=document.documentElement.getAttribute('data-theme')==='light'?'☾':'☀';
   var hash=location.hash.replace('#','');
   var match=[].slice.call(document.querySelectorAll('.toggle button')).filter(function(b){{return(b.getAttribute('onclick')||'').indexOf("'"+hash+"'")>=0;}})[0];
   if(match)match.click();
+  var activeCard=document.querySelector('.basin-card.active');
+  if(activeCard)_renderPaceChart(activeCard.id);
 }});
 var _ds={{}};
 function sortDash(th,col,type){{
@@ -650,6 +685,79 @@ function sortDash(th,col,type){{
   card.querySelectorAll('.sort-th .sa').forEach(function(s,i){{s.innerHTML=i===col?(asc?'&#9650;':'&#9660;'):''}});
 }}
 var ACE_TRACKS={_track_json};
+var ACE_PACE={_pace_json};
+var _paceCharts={{}};
+function _paceColors(){{
+  var s=getComputedStyle(document.documentElement);
+  var g=function(v){{return s.getPropertyValue(v).trim();}};
+  return {{accent:g('--accent'),accent2:g('--accent2'),muted:g('--muted'),mutedDark:g('--muted-dark'),border:g('--border')}};
+}}
+function _hexToRgba(hex,a){{
+  var h=hex.replace('#','');
+  if(h.length===3)h=h[0]+h[0]+h[1]+h[1]+h[2]+h[2];
+  var r=parseInt(h.substring(0,2),16),g=parseInt(h.substring(2,4),16),b=parseInt(h.substring(4,6),16);
+  return 'rgba('+r+','+g+','+b+','+a+')';
+}}
+function _renderPaceChart(basinKey){{
+  if(_paceCharts[basinKey])return;
+  var d=ACE_PACE[basinKey];
+  var el=document.getElementById('pace-canvas-'+basinKey);
+  if(!d||!el||typeof Chart==='undefined')return;
+  var colors=_paceColors();
+  var datasets=[
+    {{label:'p75',data:d.climatology_p75,borderWidth:0,pointRadius:0,fill:false}},
+    {{label:'p25',data:d.climatology_p25,borderWidth:0,pointRadius:0,fill:'-1',backgroundColor:_hexToRgba(colors.accent2,0.15)}},
+    {{label:'Historical average',data:d.climatology_mean,borderColor:colors.muted,borderWidth:2,borderDash:[5,5],pointRadius:0}}
+  ];
+  if(d.last_season){{
+    datasets.push({{label:'Last season',data:d.last_season,borderColor:colors.mutedDark,borderWidth:1.5,pointRadius:0}});
+  }}
+  datasets.push({{label:'This season',data:d.current_season,borderColor:colors.accent,borderWidth:3,pointRadius:0,spanGaps:false}});
+  _paceCharts[basinKey]=new Chart(el,{{
+    type:'line',
+    data:{{labels:d.day_labels,datasets:datasets}},
+    options:{{
+      responsive:true,maintainAspectRatio:false,
+      interaction:{{mode:'index',intersect:false}},
+      plugins:{{
+        legend:{{display:false}},
+        tooltip:{{filter:function(item){{return item.dataset.label!=='p75'&&item.dataset.label!=='p25';}}}}
+      }},
+      scales:{{
+        x:{{ticks:{{color:colors.muted,autoSkip:true,maxTicksLimit:8}},grid:{{display:false}}}},
+        y:{{ticks:{{color:colors.muted}},grid:{{color:colors.border}}}}
+      }}
+    }}
+  }});
+  _updatePaceStats(basinKey,d);
+}}
+function _updatePaceStats(basinKey,d){{
+  var todate=d.current_season[d.today_index]||0;
+  var normal=d.climatology_mean[d.today_index]||0;
+  var pct=normal>0?(todate/normal*100):0;
+  var elT=document.getElementById('pace-todate-'+basinKey);
+  var elN=document.getElementById('pace-normal-'+basinKey);
+  var elP=document.getElementById('pace-pct-'+basinKey);
+  if(elT)elT.textContent=todate.toFixed(1);
+  if(elN)elN.textContent=normal.toFixed(1);
+  if(elP)elP.textContent=pct.toFixed(0)+'%';
+}}
+function _restylePaceCharts(){{
+  var colors=_paceColors();
+  Object.keys(_paceCharts).forEach(function(basinKey){{
+    var chart=_paceCharts[basinKey];
+    chart.data.datasets.forEach(function(ds){{
+      if(ds.label==='p25')ds.backgroundColor=_hexToRgba(colors.accent2,0.15);
+      else if(ds.label==='Historical average')ds.borderColor=colors.muted;
+      else if(ds.label==='Last season')ds.borderColor=colors.mutedDark;
+      else if(ds.label==='This season')ds.borderColor=colors.accent;
+    }});
+    chart.options.scales.x.ticks.color=colors.muted;
+    chart.options.scales.y.ticks.color=colors.muted;
+    chart.options.scales.y.grid.color=colors.border;
+    chart.update();
+  }});
+}}
 var _trMaps={{}};
 var _SC={{TD:'#9e9e9e',TS:'#81d4fa',SS:'#81d4fa'}};
 function _tc(st,w){{
@@ -689,6 +797,7 @@ function _buildMap(slug){{
 }}
 </script>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha384-cxOPjt7s7Iz04uaHJceBmS+qpjv2JkIHNVcuOrM+YHwZOmJGBXI00mdUXEq65HTH" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/chart.js@4.5.1/dist/chart.umd.min.js" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
 <div id="global-tip" class="global-tip"></div>
 <script>
 (function(){{

--- a/ace_tracker.py
+++ b/ace_tracker.py
@@ -31,6 +31,7 @@ from ace_data import (
     get_current_season,
     calculate_yearly_totals,
     calculate_yearly_stats,
+    calculate_ace_pace,
     generate_insights,
     generate_discord_text,
     generate_console_report,
@@ -77,9 +78,11 @@ def process_basin(basin_key):
     if historical_storms:
         yearly_totals = calculate_yearly_totals(historical_storms)
         yearly_stats = calculate_yearly_stats(historical_storms)
+        ace_pace = calculate_ace_pace(historical_storms, basin_key)
     else:
         yearly_totals = BACKUP_DATA[basin_key]['yearly_totals']
         yearly_stats = None
+        ace_pace = None
 
     # Get current season
     current = get_current_season(basin_key, dataset=shared_dataset)
@@ -105,6 +108,7 @@ def process_basin(basin_key):
         'yearly_totals': yearly_totals,
         'yearly_stats': yearly_stats,
         'insights': insights,
+        'ace_pace': ace_pace,
     }
 
 

--- a/test_ace_tracker.py
+++ b/test_ace_tracker.py
@@ -20,6 +20,7 @@ from ace_data import (
     calculate_yearly_totals,
     find_similar_seasons,
     calculate_same_date_stats,
+    calculate_ace_pace,
     SYNOPTIC_TIMES,
     ACE_STATUSES,
     MIN_NAMED_STORM_WIND,
@@ -372,6 +373,118 @@ class TestSameDateStats(unittest.TestCase):
         self.assertNotIn(2026, result['yearly_ace'])
 
 
+class TestAcePace(unittest.TestCase):
+    """Tests for calculate_ace_pace() — day-by-day pace chart data."""
+
+    def _make_ace_storm(self, year, ace, month=6, day=1, duration=4, id_suffix='a'):
+        """A storm with an exact ACE value (wind_readings of 100kt repeated
+        `ace` times gives ACE == ace exactly, since (100**2)/10000 == 1.0)."""
+        return finalize_storm({
+            'id': f'AL01{year}{id_suffix}', 'name': 'Test', 'year': year,
+            'max_wind': 100, 'wind_readings': [100] * int(ace),
+            'start_date': datetime(year, month, day),
+            'end_date':   datetime(year, month, day + duration),
+            'landfall':   [],
+        })
+
+    def test_returns_none_with_no_historical_data(self):
+        """Returns None when no historical storms are available."""
+        self.assertIsNone(calculate_ace_pace([], 'atlantic'))
+
+    def test_returns_none_with_only_current_year(self):
+        """Returns None when there are zero climatology years (only the
+        current, in-progress season has data)."""
+        storms = [self._make_ace_storm(2026, 10)]
+        result = calculate_ace_pace(storms, 'atlantic', datetime(2026, 6, 28))
+        self.assertIsNone(result)
+
+    def test_excludes_current_year_from_climatology(self):
+        """A huge current-year outlier storm does not affect the
+        climatology mean/p25/p75."""
+        storms = [
+            self._make_ace_storm(2022, 10), self._make_ace_storm(2023, 20),
+            self._make_ace_storm(2024, 30), self._make_ace_storm(2025, 40),
+        ]
+        baseline = calculate_ace_pace(storms, 'atlantic', datetime(2026, 6, 11))
+        storms_with_outlier = storms + [self._make_ace_storm(2026, 999, id_suffix='outlier')]
+        result = calculate_ace_pace(storms_with_outlier, 'atlantic', datetime(2026, 6, 11))
+        self.assertEqual(result['climatology_mean'], baseline['climatology_mean'])
+        self.assertEqual(result['climatology_p25'], baseline['climatology_p25'])
+        self.assertEqual(result['climatology_p75'], baseline['climatology_p75'])
+
+    def test_includes_current_year_in_current_season_curve(self):
+        """The current year's own storm shows up (fully, once ended) in
+        current_season."""
+        storms = [
+            self._make_ace_storm(2022, 10), self._make_ace_storm(2023, 20),
+            self._make_ace_storm(2026, 15),
+        ]
+        result = calculate_ace_pace(storms, 'atlantic', datetime(2026, 6, 11))
+        # Day index 10 = June 11 = Jun 1 + 10 days; storm ended Jun 5, so
+        # by day 10 its full ACE (15) has accrued.
+        self.assertEqual(result['current_season'][10], 15)
+
+    def test_percentile_computation(self):
+        """climatology_p25/p75 match hand-computed linear-interpolation
+        percentiles for a known set of same-day cumulative ACE values."""
+        storms = [
+            self._make_ace_storm(2022, 10), self._make_ace_storm(2023, 20),
+            self._make_ace_storm(2024, 30), self._make_ace_storm(2025, 40),
+        ]
+        result = calculate_ace_pace(storms, 'atlantic', datetime(2026, 6, 11))
+        # Day index 10: all 4 storms (started Jun 1, ended Jun 5) have fully
+        # accrued. Sorted values [10,20,30,40], n=4:
+        #   p25: k=(4-1)*0.25=0.75 -> 10*0.25 + 20*0.75 = 17.5
+        #   p75: k=(4-1)*0.75=2.25 -> 30*0.75 + 40*0.25 = 32.5
+        self.assertAlmostEqual(result['climatology_p25'][10], 17.5)
+        self.assertAlmostEqual(result['climatology_p75'][10], 32.5)
+        self.assertAlmostEqual(result['climatology_mean'][10], 25.0)
+
+    def test_last_season_curve(self):
+        """last_season matches the cumulative curve for as_of_date.year - 1."""
+        storms = [
+            self._make_ace_storm(2022, 10), self._make_ace_storm(2023, 20),
+            self._make_ace_storm(2025, 40),
+        ]
+        result = calculate_ace_pace(storms, 'atlantic', datetime(2026, 6, 11))
+        self.assertEqual(result['last_season'][10], 40)
+
+    def test_last_season_none_when_absent(self):
+        """last_season is None when as_of_date.year - 1 has no storms."""
+        storms = [self._make_ace_storm(2020, 10), self._make_ace_storm(2021, 20)]
+        result = calculate_ace_pace(storms, 'atlantic', datetime(2026, 6, 11))
+        self.assertIsNone(result['last_season'])
+
+    def test_today_index_clamped_before_season_start(self):
+        """as_of_date before the season start clamps today_index to 0."""
+        storms = [self._make_ace_storm(2022, 10)]
+        result = calculate_ace_pace(storms, 'atlantic', datetime(2026, 4, 1))
+        self.assertEqual(result['today_index'], 0)
+
+    def test_today_index_clamped_after_season_end(self):
+        """as_of_date after Nov 30 clamps today_index to the last valid index."""
+        storms = [self._make_ace_storm(2022, 10)]
+        result = calculate_ace_pace(storms, 'atlantic', datetime(2026, 12, 15))
+        expected_last = (datetime(2026, 11, 30) - datetime(2026, 6, 1)).days
+        self.assertEqual(result['today_index'], expected_last)
+
+    def test_current_season_null_after_today(self):
+        """current_season values after today_index are all None."""
+        storms = [self._make_ace_storm(2022, 10), self._make_ace_storm(2026, 15)]
+        result = calculate_ace_pace(storms, 'atlantic', datetime(2026, 6, 11))
+        self.assertTrue(all(v is None for v in result['current_season'][11:]))
+
+    def test_array_lengths_consistent(self):
+        """All returned arrays share the same length."""
+        storms = [self._make_ace_storm(2022, 10), self._make_ace_storm(2023, 20)]
+        result = calculate_ace_pace(storms, 'atlantic', datetime(2026, 6, 11))
+        n = len(result['day_labels'])
+        self.assertEqual(len(result['climatology_mean']), n)
+        self.assertEqual(len(result['climatology_p25']), n)
+        self.assertEqual(len(result['climatology_p75']), n)
+        self.assertEqual(len(result['current_season']), n)
+
+
 class TestHTMLGeneration(unittest.TestCase):
     """Smoke tests for HTML generation — catches NameErrors, TypeErrors, and
     broken f-strings in generate_dashboard_html / generate_history_html without
@@ -456,6 +569,40 @@ class TestHTMLGeneration(unittest.TestCase):
             result, "Leaflet CSS SRI hash missing or truncated"
         )
         self.assertIn('crossorigin="anonymous"', result)
+
+    def test_pace_chart_embedded(self):
+        """generate_dashboard_html embeds ACE_PACE data and renders the
+        chart canvas when ace_pace is present. Uses the real
+        calculate_ace_pace output (not a hand-built dict) so this also
+        checks the return shape is genuinely JSON-serializable."""
+        basin_data = self._make_basin_data()
+        basin_data[0]['ace_pace'] = calculate_ace_pace(
+            basin_data[0]['historical_storms'], 'atlantic', datetime(2026, 6, 18)
+        )
+        result = generate_dashboard_html(basin_data)
+        self.assertIn('ACE_PACE=', result)
+        self.assertIn('pace-canvas-atlantic', result)
+
+    def test_pace_chart_omitted_without_data(self):
+        """generate_dashboard_html degrades gracefully (no KeyError) when
+        ace_pace is absent from a basin's data."""
+        basin_data = self._make_basin_data()
+        result = generate_dashboard_html(basin_data)
+        self.assertIsInstance(result, str)
+        self.assertIn('ACE_PACE=', result)  # embedded as {} when no basin has pace data
+
+    def test_chartjs_sri_hash_present(self):
+        """Dashboard HTML contains the correct full SRI hash for Chart.js.
+
+        Guards against the same truncated/wrong-hash bug that already hit
+        the Leaflet script tag once in this repo.
+        """
+        basin_data = self._make_basin_data()
+        result = generate_dashboard_html(basin_data)
+        self.assertIn(
+            'sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ',
+            result, "Chart.js SRI hash missing or truncated"
+        )
 
     def test_html_escape_applied(self):
         """html_escape() is reachable from inside the generator functions


### PR DESCRIPTION
## Summary
- New **Season Pace** chart on the dashboard (Chart.js) showing this season's cumulative ACE against the 1991-2020 climatology (mean + 25th-75th percentile band) and last season's pace, per basin.
- `ace_data.py`: extracted `_storm_ace_at_cutoff()` as a shared helper out of `calculate_same_date_stats`'s inline proration logic, then built `calculate_ace_pace()` on top of it — this guarantees the chart's climatology can never independently drift from the same-date stats already shown elsewhere on the dashboard.
- `ace_html.py`: follows the site's existing conventions exactly — Chart.js loaded via CDN the same way Leaflet is (with a verified SRI hash, not a guessed one — this repo has hit a truncated-hash bug before), and the chart data embedded as inline JS following the same pattern as the existing storm-track maps (no `fetch()`/JSON file anywhere in this codebase, so this doesn't introduce a new pattern).

## Notable implementation details
- **Hidden-canvas-on-inactive-tab pitfall handled explicitly**: only one basin's card is visible at a time, and a Chart.js chart built on a hidden canvas renders blank. Mirrors the existing lazy-build-on-visibility pattern used for the Leaflet track maps — verified by actually switching tabs and confirming the second basin's chart renders (see screenshots).
- **Theme-aware**: static chrome uses the site's existing CSS variables (themes for free); the canvas-drawn chart colors are resolved via `getComputedStyle` and explicitly re-applied on the dark/light toggle.
- **No behavior change to existing features**: `calculate_same_date_stats`'s refactor to use the new shared helper is behavior-preserving (all 5 existing tests pass unmodified).

## Test plan
- [x] `python3 -m py_compile ace_data.py ace_html.py ace_tracker.py test_ace_tracker.py`
- [x] `python3 test_ace_tracker.py` — 48/48 pass (34 existing + 14 new: `TestAcePace` covers climatology exclusion of the current season, percentile math against hand-computed values, last-season lookup, off-season date clamping; `TestHTMLGeneration` gets pace-chart embedding + Chart.js SRI hash coverage)
- [x] `python3 ace_tracker.py` end-to-end against the real ~35-year dataset, both basins — confirmed `ACE_PACE` embeds correctly with sane values (35 years of climatology, current-season values null-terminated exactly at today's date index)
- [x] Visual verification in a real browser, screenshots taken for: Atlantic dark mode (percentile band renders as a visible shaded region, not a hairline), Pacific tab after switching from Atlantic (confirms the hidden-canvas fix works — chart is NOT blank), and Pacific in light mode after toggling theme (confirms live re-coloring without reload). Stat row values (ACE to date / normal for today / % vs normal) numerically match the underlying data.

Closes #49
