### PR TITLE
Fix Atlantic forecast cone graphics folder (AT vs AL)

### DIFF
--- a/ace_data.py
+++ b/ace_data.py
@@ -1518,7 +1518,10 @@ def fetch_active_storm_cones(basin_key, storm_details):
         try:
             ts = datetime.fromisoformat(update_time.replace('Z', '+00:00'))
             time_code = ts.strftime('%d%H%M')
-            bin4 = storm_id[:4].upper()
+            # NHC's storm_graphics folder uses the ATCF basin+number for EP/CP storms,
+            # but 'AT' (not 'AL') for Atlantic storms, e.g. al032026 -> AT03.
+            graphics_prefix = 'AT' if basin_key == 'atlantic' else storm_id[:2].upper()
+            bin4 = graphics_prefix + storm_id[2:4].upper()
             atcf_id = storm_id.upper()
             url = (f'https://www.nhc.noaa.gov/storm_graphics/{bin4}/refresh/'
                    f'{atcf_id}_5day_cone+png/{time_code}_5day_cone.png')


### PR DESCRIPTION
## Summary
- PR #84 fixed the `CurrentStorms.json` `binNumber` filter (`AT` vs `AL`) so Atlantic storms pass the active-storm check, but the cone image URL still built its `storm_graphics` folder from the ATCF id (`al032026` → `AL03`), which 404s on NHC's server.
- NHC actually serves Atlantic cone graphics under `AT03`, not `AL03` — confirmed by cross-checking `https://www.nhc.noaa.gov/graphics_at3.shtml`. Pacific storms were unaffected since their folder happens to match their ATCF id (`cp012026` → `CP01`).
- Verified live: Cristobal's cone now downloads successfully to `data/cones/al032026.png`.

## Test plan
- [x] `python3 test_ace_tracker.py` — 48/48 pass
- [x] Manually called `fetch_active_storm_cones('atlantic', ...)` against live NHC data and confirmed the PNG downloads (previously 404'd)