### PR TITLE
Default dark mode to system preference for first-time visitors

### DIFF
--- a/ace_html.py
+++ b/ace_html.py
@@ -502,7 +502,7 @@ def generate_dashboard_html(basin_data):
 <link rel="icon" type="image/png" href="ace.png">
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha384-sHL9NAb7lN7rfvG5lfHpm643Xkcjzp4jFvuavGOndn6pjVqS6ny56CAt3nsEVT4H" crossorigin="anonymous" />
 <title>Hurricane ACE Dashboard | aceofcanes.com</title>
-<script>(function(){{try{{var t=localStorage.getItem('ace-theme');if(t==='light')document.documentElement.setAttribute('data-theme','light');}}catch(e){{}}}})();</script>
+<script>(function(){{try{{var t=localStorage.getItem('ace-theme');if(t==='light')document.documentElement.setAttribute('data-theme','light');else if(!t&&window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches)document.documentElement.setAttribute('data-theme','light');}}catch(e){{}}}})();</script>
 <style>
   :root {{
     --bg:#0a1628; --card:#132238; --box:#1a2d4a; --accent:#4fc3f7; --accent2:#29b6f6;
@@ -1115,7 +1115,7 @@ def generate_history_html(basin_data):
 <meta name="twitter:image" content="https://aceofcanes.com/ace_preview.png">
 <link rel="icon" type="image/png" href="ace.png">
 <title>Season History (1991–present) | aceofcanes.com</title>
-<script>(function(){{try{{var t=localStorage.getItem('ace-theme');if(t==='light')document.documentElement.setAttribute('data-theme','light');}}catch(e){{}}}})();</script>
+<script>(function(){{try{{var t=localStorage.getItem('ace-theme');if(t==='light')document.documentElement.setAttribute('data-theme','light');else if(!t&&window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches)document.documentElement.setAttribute('data-theme','light');}}catch(e){{}}}})();</script>
 <style>
   :root {{
     --bg:#0a1628; --card:#132238; --box:#1a2d4a; --accent:#4fc3f7;


### PR DESCRIPTION
Closes #71

## Summary
- The inline theme-init script (dashboard + history page) only ever checked `localStorage['ace-theme']`. First-time visitors with no saved preference always got dark mode, ignoring their OS `prefers-color-scheme`.
- Now: if no preference is stored yet, fall back to `prefers-color-scheme: light` to decide the initial theme. Anyone who has already toggled the theme (localStorage set to `light` or `dark`) is unaffected — their saved choice always wins.
- Applied to both `data-theme` init scripts (dashboard and history page — they were byte-identical).

## Test plan
- [x] `python3 test_ace_tracker.py` — 48/48 pass
- [x] Ran `ace_tracker.py` and confirmed the generated `<script>` in both `ACE_Dashboard.html` and `history.html` is valid, correctly-escaped JS
- [x] Manually traced the precedence logic: `t==='light'` → light; `t==='dark'` → stays dark (explicit choice preserved); `!t` (first visit) + system prefers light → light; otherwise default dark