### PR TITLE
Update README: fix test count, setuptools pin, structure, dark mode default

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Updated every 3 hours during hurricane season (Eastern Pacific: May 15 – Nov 3
 
 - **Real-time tracking** — current season ACE updated every 3 hours via NHC best track data
 - **Dual basin** — Atlantic and Eastern Pacific, toggle between them on each page
-- **Dark/light mode** — persisted across sessions
+- **Dark/light mode** — defaults to system preference for first-time visitors, persisted across sessions after that
 - **Season progress bar** — shows current day and percent complete
 - **Landfall data** — each storm shows where it made landfall and its intensity at the moment of impact (not just peak). Multi-landfall storms show all locations (e.g. `Florida (Cat 1) · Louisiana (Cat 3)`). Storms that never made landfall are labeled **Fish Storm**
 - **NHC development alert** — amber banner appears when NHC is tracking an area with Medium (≥40%) or High (≥70%) formation chances, with direct link to the NHC Tropical Weather Outlook
@@ -92,7 +92,7 @@ Generates in `data/`:
 python3 test_ace_tracker.py
 ```
 
-All 34 tests must pass before committing. Use the `/pre-commit` skill in Claude Code for the full checklist.
+All 48 tests must pass before committing. Use the `/pre-commit` skill in Claude Code for the full checklist.
 
 ---
 
@@ -103,14 +103,20 @@ ace-tracker/
 ├── ace_data.py             # Data fetch, ACE calc, plain-text report generation
 ├── ace_html.py             # Dashboard + history HTML rendering
 ├── ace_tracker.py          # CLI entrypoint — wires ace_data.py + ace_html.py together
-├── test_ace_tracker.py     # 34 unit + smoke tests
+├── test_ace_tracker.py     # 48 unit + smoke tests
 ├── requirements.txt        # Python dependencies
 ├── ace.png                 # Site logo (favicon + OG image)
-├── ace_preview.png         # Social share preview image
+├── ace_preview.png         # Social share preview image (copied into data/ at publish time)
 ├── landfall_cache.json     # Cached landfall geocoding results (gitignored, built by CI)
 ├── CNAME                   # Custom domain for GitHub Pages (aceofcanes.com)
 ├── robots.txt              # Search engine crawl rules
 ├── sitemap.xml             # Sitemap for search engine indexing
+├── CLAUDE.md               # Project instructions for Claude Code
+├── CONTRIBUTING.md         # Contribution guidelines
+├── docs/
+│   └── ROADMAP.md          # Planned features and roadmap
+├── images/                 # Reference/marketing images
+├── .claude/skills/          # /pre-commit, /season-start, /verify-data
 ├── .github/
 │   ├── workflows/
 │   │   ├── tests.yml       # CI: runs tests on push/PR (Python 3.10, 3.11, 3.12)
@@ -120,7 +126,6 @@ ace-tracker/
 ├── SECURITY.md
 └── data/                   # Generated output (html gitignored, images committed)
     ├── ace.png
-    ├── ace_preview.png
     ├── ACE_Dashboard.html
     ├── history.html
     └── cones/              # NHC forecast cone images, fetched fresh each run (gitignored)
@@ -171,7 +176,7 @@ The tracker falls back to `BACKUP_DATA` automatically. You'll see:
 The `landfall_cache.json` is built on the first run and cached by GitHub Actions. The first run after a fresh clone will geocode all historical storms (~1 min extra). Every subsequent run reads from cache.
 
 **`pkg_resources` deprecation warning**
-Tropycal 1.4 uses `pkg_resources` which is deprecated in setuptools 81+. `requirements.txt` pins `setuptools<82` as a workaround. Monitor [Tropycal releases](https://github.com/tropycal/tropycal/releases) for a fix.
+Tropycal uses `pkg_resources` which is deprecated in setuptools 81+. `requirements.txt` pins `setuptools<84` as a workaround. Monitor [Tropycal releases](https://github.com/tropycal/tropycal/releases) for a fix.
 
 ---
 


### PR DESCRIPTION
## Summary
- Test count corrected from 34 to 48 (matches actual `test_ace_tracker.py` count)
- `setuptools` pin in troubleshooting corrected from `<82` to `<84` (matches current requirements.txt)
- Project structure tree updated: added CLAUDE.md, CONTRIBUTING.md, docs/, images/, .claude/skills/; corrected ace_preview.png location note
- Dark mode feature bullet updated to mention system-preference default for first-time visitors (#89)