### PR TITLE
Fix stale test count in skills (25 -> 48)

### DIFF
--- a/.claude/skills/pre-commit/SKILL.md
+++ b/.claude/skills/pre-commit/SKILL.md
@@ -12,7 +12,7 @@ disable-model-invocation: false
 python3 test_ace_tracker.py
 ```
 
-All 25 tests must pass. If any fail: fix before committing.
+All 48 tests must pass. If any fail: fix before committing.
 
 ## 2. Run the Full Tracker
 

--- a/.claude/skills/season-start/SKILL.md
+++ b/.claude/skills/season-start/SKILL.md
@@ -60,4 +60,4 @@ When the first named storm forms, run the tracker and verify:
 python3 test_ace_tracker.py
 ```
 
-All 25 tests must still pass.
+All 48 tests must still pass.


### PR DESCRIPTION
## Summary
- pre-commit and season-start skills still referenced the old 25-test count from before the test suite grew to 48. Same staleness pattern already fixed in CLAUDE.md/SECURITY.md/README.md in #90/#91.