### PR TITLE
Sprint 0: fix season-rank double-count, unify ACE formula, refresh landfall cache

### DIFF
--- a/.claude/skills/pre-commit/SKILL.md
+++ b/.claude/skills/pre-commit/SKILL.md
@@ -12,7 +12,7 @@ disable-model-invocation: false
 python3 test_ace_tracker.py
 ```
 
-All 48 tests must pass. If any fail: fix before committing.
+All 59 tests must pass. If any fail: fix before committing.
 
 ## 2. Run the Full Tracker
 

--- a/.claude/skills/season-start/SKILL.md
+++ b/.claude/skills/season-start/SKILL.md
@@ -60,4 +60,4 @@ When the first named storm forms, run the tracker and verify:
 python3 test_ace_tracker.py
 ```
 
-All 48 tests must still pass.
+All 59 tests must still pass.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Same thresholds for both Atlantic and Eastern Pacific:
 
 ```bash
 python3 ace_tracker.py        # generates HTML files in data/
-python3 test_ace_tracker.py   # 48 tests — ALL must pass before committing
+python3 test_ace_tracker.py   # 59 tests — ALL must pass before committing
 pip3 install -r requirements.txt
 ```
 
@@ -47,12 +47,12 @@ pip3 install -r requirements.txt
 
 `ace_tracker.py`: CLI entrypoint — `process_basin()` and `main()`, wiring `ace_data.py` and `ace_html.py` together. Run via `python3 ace_tracker.py`.
 
-`test_ace_tracker.py`: 48 tests across 11 classes — categorization, ACE formula, NOAA classification, storm finalization, yearly totals, similar-season matching, ACE pace chart data. Imports directly from `ace_data.py`/`ace_html.py`.
+`test_ace_tracker.py`: 59 tests across 14 classes — categorization, ACE formula, NOAA classification, storm finalization, yearly totals, similar-season matching, ACE pace chart data. Imports directly from `ace_data.py`/`ace_html.py`.
 
 ## Repository Rules
 
 - **Only @jeremypfi can approve and merge PRs** (CODEOWNERS + branch protection)
-- All 48 tests must pass before committing — run `/pre-commit` skill
+- All 59 tests must pass before committing — run `/pre-commit` skill
 - Never commit `data/*.html` — gitignored
 - **Before opening any PR:** fetch origin and merge main into the branch first:
   ```bash

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Generates in `data/`:
 python3 test_ace_tracker.py
 ```
 
-All 48 tests must pass before committing. Use the `/pre-commit` skill in Claude Code for the full checklist.
+All 59 tests must pass before committing. Use the `/pre-commit` skill in Claude Code for the full checklist.
 
 ---
 
@@ -103,7 +103,7 @@ ace-tracker/
 ├── ace_data.py             # Data fetch, ACE calc, plain-text report generation
 ├── ace_html.py             # Dashboard + history HTML rendering
 ├── ace_tracker.py          # CLI entrypoint — wires ace_data.py + ace_html.py together
-├── test_ace_tracker.py     # 48 unit + smoke tests
+├── test_ace_tracker.py     # 59 unit + smoke tests
 ├── requirements.txt        # Python dependencies
 ├── ace.png                 # Site logo (favicon + OG image)
 ├── ace_preview.png         # Social share preview image (copied into data/ at publish time)

--- a/VERIFICATION_REPORT.md
+++ b/VERIFICATION_REPORT.md
@@ -1,0 +1,37 @@
+# Data Verification Report
+
+## Sprint 0 — Data accuracy fixes (Aug 15, 2026)
+
+Verified after unifying the ACE formula (dashboard + history now both use the
+synoptic-time calculation, `ace_from_winds`) and fixing the season-rank
+double-count.
+
+### Per-storm ACE vs official Tropycal/HURDAT2 values
+
+| Storm | Basin | Max wind | Official ACE | Tracker ACE | Diff | Duration |
+|---|---|---|---|---|---|---|
+| Katrina 2005 | Atlantic | 150 kt ✅ | 20.0050 | 20.0050 | 0.00% ✅ | 8d ✅ |
+| Sandy 2012 | Atlantic | 100 kt ✅ | 13.6675 | 13.6675 | 0.00% ✅ | 10d ✅ |
+| Ida 2021 | Atlantic | 130 kt ✅ | 10.5800 | 10.5800 | 0.00% ✅ | 10d ✅ |
+| Patricia 2015 | E. Pacific | 185 kt ✅ | 17.3225 | 17.3225 | 0.00% ✅ | 5d ✅ |
+| Rosa 2018 | E. Pacific | 130 kt ✅ | 16.9525 | 16.9525 | 0.00% ✅ | 8d ✅ |
+| Genevieve 2026 (BTK, current season) | E. Pacific | 140 kt ✅ | 26.1175 | 26.1175 | 0.00% ✅ | 12d ✅ |
+
+**Summary: 6/6 wind exact, 6/6 ACE within 5% (all exact), 6/6 duration within 1 day.**
+
+### Season rank
+
+1991–2026 inclusive = **36 seasons**. Generated dashboard now reports
+"#N of 36" (previously "of 37" due to the current year being counted twice).
+Dashboard and history pages report identical per-storm ACE for all 2026 storms
+(spot-checked Genevieve, Fausto, Lala, Hernan on both pages).
+
+### Method
+
+Official values pulled fresh via `tropycal.tracks.TrackDataset(source='hurdat',
+include_btk=True)`; tracker values computed via
+`ace_from_winds(_extract_synoptic_winds(storm))` — the single formula now used
+by every code path.
+
+Previous baseline (April 2026): 100% wind, 83% ACE within 5%, 100% duration.
+This run improves ACE agreement to 100% exact.

--- a/ace_data.py
+++ b/ace_data.py
@@ -185,11 +185,19 @@ def get_season_projection(current_ace, basin_key, as_of_date=None):
 
 
 
+def ace_from_winds(wind_readings):
+    """ACE from synoptic-time wind readings: Σ(V²max) × 10⁻⁴.
+
+    Single source of truth for the ACE formula — used for both historical
+    storms (finalize_storm) and the current season, so the dashboard and
+    history page can never disagree about the same storm.
+    """
+    return round(sum(w * w for w in wind_readings) / 10000.0, 4)
+
+
+
 def finalize_storm(storm):
-    ace = 0.0
-    for wind in storm['wind_readings']:
-        ace += (wind ** 2) / 10000.0
-    storm['ace'] = round(ace, 4)
+    storm['ace'] = ace_from_winds(storm['wind_readings'])
     storm['category'] = get_category(storm['max_wind'])
     storm['is_major'] = is_major(storm['max_wind'])
     if storm['start_date'] and storm['end_date']:
@@ -293,6 +301,34 @@ def _load_landfall_cache():
     except Exception as e:
         logger.warning(f"Could not load landfall cache: {e}")
     return {}
+
+
+
+def _last_track_stamp(storm_obj):
+    """Timestamp string of a storm's last track point.
+
+    Used in cache keys that must auto-invalidate when a new advisory adds
+    track data to an in-progress storm."""
+    try:
+        last_t = storm_obj.time[-1]
+        return last_t.strftime('%Y%m%d%H') if hasattr(last_t, 'strftime') else str(last_t)[:13]
+    except Exception:
+        return 'unknown'
+
+
+
+def _drop_stale_storm_keys(cache, storm_id, keep_key, prefix):
+    """Remove outdated cache entries for one in-progress storm, scoped to one
+    key family (`cur` or `geo`): the legacy bare-id key plus any
+    `{prefix}:{id}:{timestamp}` keys other than `keep_key`. The two families
+    cache different computations, so pruning never crosses between them.
+    Returns True if anything was removed."""
+    sid = str(storm_id)
+    stale = [k for k in cache
+             if k != keep_key and (k == sid or k.startswith(f"{prefix}:{sid}:"))]
+    for k in stale:
+        del cache[k]
+    return bool(stale)
 
 
 
@@ -519,8 +555,16 @@ def parse_hurdat2(basin_key, dataset=None):
                         # Extract synoptic-time wind readings for ACE calculation
                         wind_readings = _extract_synoptic_winds(storm_obj)
 
-                        # Landfall: use cache for completed seasons, compute otherwise
-                        cache_key = str(storm_id)
+                        # Landfall: completed seasons cache by bare id (track data
+                        # is immutable after post-season reanalysis). Current-season
+                        # storms key by id + last track time so each new advisory
+                        # invalidates the entry instead of serving stale landfalls.
+                        if storm_year < current_year:
+                            cache_key = str(storm_id)
+                        else:
+                            cache_key = f"cur:{storm_id}:{_last_track_stamp(storm_obj)}"
+                            if _drop_stale_storm_keys(lf_cache, storm_id, cache_key, 'cur'):
+                                lf_cache_dirty = True
                         if cache_key in lf_cache:
                             landfall = lf_cache[cache_key]
                         else:
@@ -556,7 +600,10 @@ def parse_hurdat2(basin_key, dataset=None):
         print(f"  ✓ Loaded {len(storms)} storms from {START_YEAR}-present via Tropycal")
         if lf_cache_dirty:
             _save_landfall_cache(lf_cache)
-            cached_pct = round(sum(1 for s in storms if str(s['id']) in lf_cache) / len(storms) * 100) if storms else 0
+            _timestamped = {k.rsplit(':', 1)[0] + ':' for k in lf_cache if k.startswith('cur:')}
+            cached_pct = round(sum(1 for s in storms
+                                   if str(s['id']) in lf_cache or f"cur:{s['id']}:" in _timestamped)
+                               / len(storms) * 100) if storms else 0
             print(f"  ✓ Landfall cache updated ({len(lf_cache)} entries, {cached_pct}% hit rate this run)")
         else:
             print(f"  ✓ Landfall cache: all {len(lf_cache)} entries served from cache (0 geocoding calls)")
@@ -633,9 +680,15 @@ def get_current_season(basin_key, dataset=None):
                         if storm_name.upper() == 'UNNAMED':
                             continue
 
-                        # Get ACE directly from Tropycal (if available)
-                        # Tropycal calculates ACE for us
-                        storm_ace = storm_obj.ace if hasattr(storm_obj, 'ace') and storm_obj.ace else 0.0
+                        # ACE via our own synoptic-time method (same as the
+                        # historical path) so the dashboard and history page
+                        # always agree. Tropycal's value is a cross-check only.
+                        storm_ace = ace_from_winds(_extract_synoptic_winds(storm_obj))
+                        tropycal_ace = storm_obj.ace if hasattr(storm_obj, 'ace') and storm_obj.ace else 0.0
+                        if tropycal_ace and abs(storm_ace - tropycal_ace) > 0.25:
+                            logger.warning(
+                                f"ACE cross-check mismatch for {storm_id}: "
+                                f"computed {storm_ace:.2f} vs Tropycal {tropycal_ace:.2f}")
 
                         # Max wind while tropical/subtropical only (same logic as primary path)
                         tropical_types = {'TD', 'TS', 'HU', 'SS', 'SD'}
@@ -701,12 +754,9 @@ def get_current_season(basin_key, dataset=None):
                         # when new track data arrives for an active storm.
                         landfall = get_landfall_locations(storm_obj)
                         if not landfall:
-                            try:
-                                last_t   = storm_obj.time[-1]
-                                last_str = last_t.strftime('%Y%m%d%H') if hasattr(last_t, 'strftime') else str(last_t)[:13]
-                            except Exception:
-                                last_str = 'unknown'
-                            geo_key = f"geo:{storm_id}:{last_str}"
+                            geo_key = f"geo:{storm_id}:{_last_track_stamp(storm_obj)}"
+                            if _drop_stale_storm_keys(cs_lf_cache, storm_id, geo_key, 'geo'):
+                                cs_lf_dirty = True
                             if geo_key in cs_lf_cache:
                                 landfall = cs_lf_cache[geo_key]
                             else:
@@ -821,6 +871,23 @@ def calculate_yearly_totals(storms):
     for year in totals:
         totals[year] = round(totals[year], 2)
     return totals
+
+
+
+def rank_current_season(yearly_totals, current_year, current_ace):
+    """Rank the in-progress season against history without double-counting.
+
+    `yearly_totals` already contains the current year (parse_hurdat2 loads
+    storms through the present), so the live total must OVERRIDE that entry
+    rather than be appended alongside it — appending duplicates the year,
+    inflates the season count by one, and can report the wrong rank.
+
+    Returns (rank, total_seasons).
+    """
+    merged = {**yearly_totals, current_year: current_ace}
+    ordered = sorted(merged.items(), key=lambda x: x[1], reverse=True)
+    rank = next(i + 1 for i, (y, _) in enumerate(ordered) if y == current_year)
+    return rank, len(ordered)
 
 
 
@@ -1119,10 +1186,7 @@ def generate_insights(basin_key, current, yearly_totals, historical_storms, year
             insights.append(f"📈 Most Similar Seasons: {similar_links}{label}")
 
     # 4. Historical ranking — pace rank (same-date) + full-season rank
-    all_years_full = list(yearly_totals.items()) + [(current_year, current_ace)]
-    all_years_full.sort(key=lambda x: x[1], reverse=True)
-    full_rank = next(i + 1 for i, (y, _) in enumerate(all_years_full) if y == current_year)
-    total_seasons = len(all_years_full)
+    full_rank, total_seasons = rank_current_season(yearly_totals, current_year, current_ace)
 
     if sd:
         sd_with_current = dict(sd['yearly_ace'])
@@ -1264,11 +1328,7 @@ def generate_discord_text(basin_key, current, yearly_totals, insights):
     lines.append("")
 
     # Historical rank
-    all_years = list(yearly_totals.items())
-    all_years.append((current_year, current_ace))
-    all_years.sort(key=lambda x: x[1], reverse=True)
-    rank = next(i + 1 for i, (y, _) in enumerate(all_years) if y == current_year)
-    total_seasons = len(all_years)
+    rank, total_seasons = rank_current_season(yearly_totals, current_year, current_ace)
     lines.append(f"Historical Rank: #{rank} of {total_seasons} (since {START_YEAR})")
 
     # Top 3 similar seasons

--- a/ace_html.py
+++ b/ace_html.py
@@ -18,6 +18,7 @@ from ace_data import (
     get_category,
     get_noaa_classification,
     get_season_projection,
+    rank_current_season,
     fetch_nhc_disturbances,
     fetch_active_storm_cones,
 )
@@ -391,10 +392,7 @@ def generate_dashboard_html(basin_data):
         if preseason:
             lower_section = _preseason_html(bd['basin_key'], yearly_totals, current_year)
         else:
-            all_years = list(yearly_totals.items()) + [(current_year, current_ace)]
-            all_years.sort(key=lambda x: x[1], reverse=True)
-            rank = next(i + 1 for i, (y, _) in enumerate(all_years) if y == current_year)
-            total_seasons = len(all_years)
+            rank, total_seasons = rank_current_season(yearly_totals, current_year, current_ace)
             storm_html, track_data = storm_rows_html(current, cone_images)
             all_track_data.update(track_data)
             lower_section = f'''
@@ -438,10 +436,7 @@ def generate_dashboard_html(basin_data):
         <div class="stat-box major-box"><div class="stat-label">Major Hurricanes</div><div class="stat-value">0</div></div>
       </div>'''
         else:
-            all_years = list(yearly_totals.items()) + [(current_year, current_ace)]
-            all_years.sort(key=lambda x: x[1], reverse=True)
-            rank = next(i + 1 for i, (y, _) in enumerate(all_years) if y == current_year)
-            total_seasons = len(all_years)
+            rank, total_seasons = rank_current_season(yearly_totals, current_year, current_ace)
             stats_grid = f'''
       <div class="stats-grid">
         <div class="stat-box ace-total">

--- a/test_ace_tracker.py
+++ b/test_ace_tracker.py
@@ -16,11 +16,15 @@ from ace_data import (
     get_category,
     is_major,
     get_noaa_classification,
+    ace_from_winds,
     finalize_storm,
     calculate_yearly_totals,
+    rank_current_season,
     find_similar_seasons,
     calculate_same_date_stats,
     calculate_ace_pace,
+    _drop_stale_storm_keys,
+    _last_track_stamp,
     SYNOPTIC_TIMES,
     ACE_STATUSES,
     MIN_NAMED_STORM_WIND,
@@ -618,6 +622,92 @@ class TestHTMLGeneration(unittest.TestCase):
         result = generate_dashboard_html(basin_data)
         self.assertIn('Test&amp;Storm', result)
         self.assertNotIn('<script>alert', result)
+
+
+class TestRankCurrentSeason(unittest.TestCase):
+    """Season ranking must not double-count the in-progress year (Sprint 0 fix)."""
+
+    def test_current_year_present_is_not_double_counted(self):
+        # parse_hurdat2 loads through the present, so yearly_totals already
+        # holds the current year — the old code appended it again.
+        totals = {2024: 100.0, 2025: 50.0, 2026: 10.0}
+        rank, total_seasons = rank_current_season(totals, 2026, 10.0)
+        self.assertEqual(total_seasons, 3)
+        self.assertEqual(rank, 3)
+
+    def test_live_total_overrides_historical_entry(self):
+        totals = {2024: 100.0, 2025: 50.0, 2026: 60.0}
+        rank, total_seasons = rank_current_season(totals, 2026, 120.0)
+        self.assertEqual(total_seasons, 3)
+        self.assertEqual(rank, 1)
+
+    def test_current_year_absent_is_added_once(self):
+        totals = {2024: 100.0, 2025: 50.0}
+        rank, total_seasons = rank_current_season(totals, 2026, 75.0)
+        self.assertEqual(total_seasons, 3)
+        self.assertEqual(rank, 2)
+
+
+class TestAceFromWinds(unittest.TestCase):
+    """Single ACE formula shared by historical and current-season paths."""
+
+    def test_matches_finalize_storm(self):
+        winds = [35, 50, 65, 100]
+        storm = finalize_storm({
+            'wind_readings': winds, 'max_wind': 100,
+            'start_date': None, 'end_date': None,
+        })
+        self.assertEqual(ace_from_winds(winds), storm['ace'])
+
+    def test_known_value(self):
+        # 50² + 50² = 5000 → 0.5 ACE
+        self.assertEqual(ace_from_winds([50, 50]), 0.5)
+
+    def test_empty_readings(self):
+        self.assertEqual(ace_from_winds([]), 0.0)
+
+
+class TestLandfallCacheInvalidation(unittest.TestCase):
+    """Current-season landfall cache entries must refresh with new advisories."""
+
+    def test_stale_bare_and_old_timestamped_keys_are_dropped(self):
+        cache = {
+            'AL012026': [('x', 'y')],              # stale legacy bare key
+            'cur:AL012026:2026081000': [('a',)],   # older advisory
+            'cur:AL012026:2026081512': [('b',)],   # current key — kept
+            'AL012025': [('keep',)],               # different storm — kept
+        }
+        changed = _drop_stale_storm_keys(cache, 'AL012026', 'cur:AL012026:2026081512', 'cur')
+        self.assertTrue(changed)
+        self.assertEqual(set(cache), {'cur:AL012026:2026081512', 'AL012025'})
+
+    def test_pruning_is_scoped_to_one_key_family(self):
+        # A cur:-family prune must never remove geo: entries (different computation).
+        cache = {
+            'geo:AL012026:2026081512': [('geo',)],
+            'cur:AL012026:2026081000': [('old',)],
+        }
+        _drop_stale_storm_keys(cache, 'AL012026', 'cur:AL012026:2026081512', 'cur')
+        self.assertIn('geo:AL012026:2026081512', cache)
+        self.assertNotIn('cur:AL012026:2026081000', cache)
+
+    def test_no_change_returns_false(self):
+        cache = {'cur:AL012026:2026081512': [('b',)]}
+        changed = _drop_stale_storm_keys(cache, 'AL012026', 'cur:AL012026:2026081512', 'cur')
+        self.assertFalse(changed)
+        self.assertEqual(len(cache), 1)
+
+    def test_last_track_stamp_formats_datetime(self):
+        class FakeStorm:
+            time = [datetime(2026, 8, 15, 12)]
+        self.assertEqual(_last_track_stamp(FakeStorm()), '2026081512')
+
+    def test_last_track_stamp_handles_missing_track(self):
+        class Broken:
+            @property
+            def time(self):
+                raise RuntimeError('no track')
+        self.assertEqual(_last_track_stamp(Broken()), 'unknown')
 
 
 def run_tests():


### PR DESCRIPTION
## Data-accuracy fixes only — zero UI changes

Three bugs found in the Aug 15 evaluation, all affecting numbers visitors see on the live site:

### 1. Season rank was off by one (and could be wrong)
`yearly_totals` already includes the in-progress year (the history loop runs through the present), but four call sites appended `(current_year, current_ace)` again — duplicating the year, inflating the count ("#N of **37**" instead of 36), and taking the rank from whichever duplicate sorted first. All four sites now use a shared `rank_current_season()` helper that **overrides** the entry instead of appending it.

### 2. Dashboard and history could disagree on a storm's ACE
The dashboard trusted Tropycal's `storm.ace`; the history page computed its own synoptic-time value. Both now use a single `ace_from_winds()` formula (Σ V²max × 10⁻⁴ at 00/06/12/18Z, TS/HU/SS only). Tropycal's value is kept as a logged cross-check.

### 3. Current-season landfalls were cached forever
`parse_hurdat2` cached landfalls by bare storm id with no invalidation, so an in-progress storm's landfall never refreshed as new advisories arrived (stale `AL012026`/`EP042026` entries were already in the cache). Current-season entries are now keyed by id + last-track timestamp (the same pattern the `geo:` keys already used) and stale keys — including the legacy bare-id ones — are pruned on write.

## Verification
- **59/59 tests pass** (11 new: rank helper, shared ACE formula, cache invalidation/pruning)
- Full local generation: dashboard now reports **#N of 36** (1991–2026 = 36 seasons ✓); dashboard and history report identical ACE for all 2026 storms (spot-checked Genevieve, Fausto, Lala, Hernan)
- **6/6 storms verified 0.00% off official HURDAT2 values** (Katrina '05, Sandy '12, Ida '21, Patricia '15, Rosa '18, Genevieve '26 incl. BTK) — see `VERIFICATION_REPORT.md`

## Notes
- Displayed values will shift slightly after merge — that's the fix, not a regression (current live numbers are inconsistent between pages).
- Rollback: `git revert` this merge, or reset to tag `pre-roadmap-2026-08`.
- Test-count references updated 48 → 59 in CLAUDE.md and skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)