### PR TITLE
Fix track map basemap: add CARTO API key to tile URL

### DIFF
--- a/ace_html.py
+++ b/ace_html.py
@@ -866,7 +866,7 @@ function _buildMap(slug){{
   var el=document.getElementById('trmap-'+slug);
   if(!d||!d.points||!d.points.length||!el||el._leaflet_id){{_hideTrackSkeleton(slug);return;}}
   var map=L.map(el,{{zoomControl:true,attributionControl:true}});
-  var tiles=L.tileLayer('https://{{s}}.basemaps.cartocdn.com/dark_all/{{z}}/{{x}}/{{y}}{{r}}.png',{{
+  var tiles=L.tileLayer('https://{{s}}.basemaps.cartocdn.com/dark_all/{{z}}/{{x}}/{{y}}{{r}}.png?key=cb1_2ju7_1_dab4d1e9c4e0819a594bda11',{{
     attribution:'&copy; <a href="https://www.openstreetmap.org/copyright">OSM</a> &copy; <a href="https://carto.com/">CARTO</a>',
     subdomains:'abcd',maxZoom:10
   }}).addTo(map);


### PR DESCRIPTION
## Summary
- CARTO now requires an API key for their raster basemap tile service; without it the dark-mode track map on storm detail panels showed an "API KEY REQUIRED" watermark instead of the actual map.
- Added a free CARTO basemap key (scoped to basemaps only, no data-warehouse access) as a `key` query param on the tile URL at `ace_html.py:869`.
- Filed #102 to track migrating off the raster PNG service to CARTO's vector tiles (MapLibre GL) longer-term, since CARTO has signaled the raster service may stop receiving map data updates.

## Test plan
- [x] `python3 test_ace_tracker.py` — all 59 tests pass
- [x] `python3 ace_tracker.py` — dashboard regenerated, confirmed tile URL in output HTML includes the key
- [ ] Visually confirm the storm track map renders without the watermark on the live dashboard after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)