### PR TITLE
Fix spaghetti-track dateline wraparound and stale active-storm status (#95)

### DIFF
--- a/ace_data.py
+++ b/ace_data.py
@@ -1585,13 +1585,19 @@ def fetch_active_storm_cones(basin_key, storm_details):
     filename embeds the forecast advisory's update time, which we read from
     CurrentStorms.json rather than guessing.
 
+    While fetching, also cross-checks the 48h last-track-point 'is_active' heuristic
+    against NHC's live active-storm list and mutates storm_details in place to
+    correct it — the heuristic alone leaves dissipated storms marked active for up
+    to 48h after their final advisory (#95). If the fetch fails, is_active is left
+    untouched (fail open) rather than losing active-storm UI to a transient outage.
+
     Returns a dict of storm_name -> relative path (e.g. 'cones/ep042026.png'),
     or {} if nothing is active or the fetch fails.
     """
     import urllib.request
 
-    active_names = {name.upper() for name, d in storm_details.items() if d.get('is_active')}
-    if not active_names:
+    candidate_names = {name.upper() for name, d in storm_details.items() if d.get('is_active')}
+    if not candidate_names:
         return {}
 
     try:
@@ -1605,6 +1611,23 @@ def fetch_active_storm_cones(basin_key, storm_details):
         return {}
 
     prefixes = NHC_BIN_PREFIXES.get(basin_key, ())
+
+    live_active_names = {
+        (storm.get('name') or '').upper()
+        for storm in data.get('activeStorms', [])
+        if (storm.get('binNumber') or '').startswith(prefixes)
+    }
+
+    for stale_name in candidate_names - live_active_names:
+        for orig_name, details in storm_details.items():
+            if orig_name.upper() == stale_name:
+                details['is_active'] = False
+                break
+
+    active_names = candidate_names & live_active_names
+    if not active_names:
+        return {}
+
     cone_dir = os.path.join('data', 'cones')
     images = {}
 

--- a/ace_html.py
+++ b/ace_html.py
@@ -275,7 +275,10 @@ def generate_dashboard_html(basin_data):
             is_major = wind >= 96
             is_active = d.get('is_active', False)
             track_points = d.get('track_points', [])
-            spaghetti = d.get('spaghetti', {})
+            # spaghetti was fetched under the pre-cross-check is_active heuristic
+            # (ace_data.py), so suppress it here if is_active was since corrected
+            # to False — a dissipated storm's stale forecast isn't worth showing.
+            spaghetti = d.get('spaghetti', {}) if is_active else {}
             start_date = d.get('start_date', '—')
             slug = name.lower().replace(' ', '-')
 
@@ -878,6 +881,18 @@ function _hideTrackSkeleton(slug){{
   var sk=document.getElementById('trskel-'+slug);
   if(sk)sk.style.display='none';
 }}
+function _unwrapLon(prevLon,lon){{
+  while(lon-prevLon>180)lon-=360;
+  while(lon-prevLon<-180)lon+=360;
+  return lon;
+}}
+function _unwrapSeries(lls){{
+  var out=[lls[0].slice()];
+  for(var i=1;i<lls.length;i++){{
+    out.push([lls[i][0],_unwrapLon(out[i-1][1],lls[i][1])]);
+  }}
+  return out;
+}}
 function _buildMap(slug){{
   var d=ACE_TRACKS[slug];
   var el=document.getElementById('trmap-'+slug);
@@ -889,9 +904,9 @@ function _buildMap(slug){{
   }}).addTo(map);
   tiles.on('load',function(){{_hideTrackSkeleton(slug);}});
   setTimeout(function(){{_hideTrackSkeleton(slug);}},4000);
-  var pts=d.points,lls=pts.map(function(p){{return[p.lat,p.lon];}});
+  var pts=d.points,lls=_unwrapSeries(pts.map(function(p){{return[p.lat,p.lon];}}));
   for(var i=0;i<pts.length-1;i++){{
-    L.polyline([[pts[i].lat,pts[i].lon],[pts[i+1].lat,pts[i+1].lon]],{{color:_tc(pts[i].status,pts[i].wind),weight:5,opacity:1}}).addTo(map);
+    L.polyline([lls[i],lls[i+1]],{{color:_tc(pts[i].status,pts[i].wind),weight:5,opacity:1}}).addTo(map);
   }}
   pts.forEach(function(p,i){{
     var c=_tc(p.status,p.wind),last=(i===pts.length-1);
@@ -906,7 +921,11 @@ function _buildMap(slug){{
     Object.keys(d.spaghetti).forEach(function(model){{
       var mpts=d.spaghetti[model];
       if(!mpts||!mpts.length)return;
-      var mlls=mpts.map(function(p){{return[p.lat,p.lon];}});
+      // Anchor to the storm's last known position so this model's series
+      // unwraps in the same longitude frame as the BTK track and any other
+      // model — otherwise each series could independently drift to opposite
+      // sides of the antimeridian and the combined bounds would be wrong.
+      var mlls=_unwrapSeries([lls[lls.length-1]].concat(mpts.map(function(p){{return[p.lat,p.lon];}}))).slice(1);
       var color=_SPAG_COLORS[model]||'#ffffff',label=_SPAG_LABELS[model]||model;
       L.polyline(mlls,{{color:color,weight:model==='OFCL'?3:2,opacity:0.85,dashArray:model==='OFCL'?null:'4,4'}})
         .bindTooltip(label,{{sticky:true}}).addTo(spagGroup);


### PR DESCRIPTION
## Summary

Two bugs found while smoke-testing the just-merged spaghetti tracks feature (#104) against real active storms:

**1. Dateline wraparound (new, introduced by #104)**
Lala's forecast tracks cross the International Date Line (e.g. AVNO's longitude sequence runs `-179.8 → 179.7 → 178.8...`). Leaflet draws straight segments between raw lon values with no wraparound awareness, so that crossing rendered as a line spanning almost the entire map width instead of a short local segment. Added `_unwrapLon`/`_unwrapSeries` in `ace_html.py` and applied them to both the BTK track and each spaghetti model's polyline, anchoring every series to a shared frame (relative to the storm's last known position) so the combined map bounds stay correct too.

**2. Closes #95 — stale active-storm status**
Comparing the live dashboard against NHC's actual Pacific outlook showed Dolly (Atlantic) and Lala (Pacific) still marked "Active Storm" well after NHC had dropped their advisories — only Karina and Lowell were genuinely active. Root cause: `is_active` is set from a 48h last-track-point heuristic (`ace_data.py`), which doesn't know a storm dissipated until that window fully elapses. `fetch_active_storm_cones()` already fetches NHC's `CurrentStorms.json` for cone images, so it now also cross-checks the heuristic against that live list and corrects `is_active` in place — fail-open if the fetch itself errors, so a transient NHC outage doesn't wrongly hide a real active storm. A storm downgraded this way also has its spaghetti overlay suppressed, since that forecast data was fetched under the stale heuristic before the correction ran.

## Test plan
- [x] `python3 test_ace_tracker.py` — all 59 tests pass
- [x] Regenerated the live dashboard against real current data; confirmed only Karina and Lowell (the two genuinely active NHC storms at time of testing) are marked active, with Dolly/Lala correctly downgraded and their spaghetti overlays suppressed
- [x] Simulated the unwrap fix against Lala's real AVNO forecast coordinates in isolation — sequence stays continuous (`-178.9 → -179.4 → ... → -181.2`) instead of jumping back across the dateline
- [x] Extracted and syntax-checked the generated inline JS with `node --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)